### PR TITLE
liine

### DIFF
--- a/Memory_Test/cache.py
+++ b/Memory_Test/cache.py
@@ -118,5 +118,5 @@ class Cache:
         if line.use < self.mapping:
             line.use = self.mapping
             for other in set:
-                if other is not liine and other.use > use:
+                if other is not line and other.use > use:
                     other.use -= 1


### PR DESCRIPTION
121:  keyword line was mispelled "liine"